### PR TITLE
Inf-1723/SEB-35 backport msldap user auth from v2.x

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,6 +92,13 @@ class icingaweb2::config (
         base_dn             => $::icingaweb2::auth_ldap_base_dn,
       }
     }
+    'msldap': {
+      icingaweb2::config::authentication_database { 'Active Directory Authentication':
+        auth_section  => 'icingaweb2',
+        auth_resource => $::icingaweb2::auth_resource,
+      }
+    }
+    
     default: {}
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,7 +93,7 @@ class icingaweb2::config (
       }
     }
     'msldap': {
-      icingaweb2::config::authentication_database { 'Active Directory Authentication':
+      icingaweb2::config::authentication_msldap { 'Active Directory Authentication':
         auth_section  => 'icingaweb2',
         auth_resource => $::icingaweb2::auth_resource,
         filter              => $::icingaweb2::auth_ldap_filter,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -96,6 +96,8 @@ class icingaweb2::config (
       icingaweb2::config::authentication_database { 'Active Directory Authentication':
         auth_section  => 'icingaweb2',
         auth_resource => $::icingaweb2::auth_resource,
+        filter              => $::icingaweb2::auth_ldap_filter,
+        base_dn             => $::icingaweb2::auth_ldap_base_dn,
       }
     }
     

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -96,8 +96,8 @@ class icingaweb2::config (
       icingaweb2::config::authentication_msldap { 'Active Directory Authentication':
         auth_section  => 'icingaweb2',
         auth_resource => $::icingaweb2::auth_resource,
-        filter              => $::icingaweb2::auth_ldap_filter,
-        base_dn             => $::icingaweb2::auth_ldap_base_dn,
+        filter        => $::icingaweb2::auth_ldap_filter,
+        base_dn       => $::icingaweb2::auth_ldap_base_dn,
       }
     }
     

--- a/manifests/config/authentication_msldap.pp
+++ b/manifests/config/authentication_msldap.pp
@@ -1,0 +1,30 @@
+# == Define: icingaweb2::config::authentication_ldap
+#
+# Sets up an authentication definition for LDAP.
+#
+define icingaweb2::config::authentication_msldap (
+  $auth_section = $title,
+  $auth_resource = undef,
+  $backend = 'msldap',
+){
+
+  Ini_Setting {
+    ensure  => present,
+    require => File["${::icingaweb2::config_dir}/authentication.ini"],
+    path    => "${::icingaweb2::config_dir}/authentication.ini",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} resource":
+    section => $auth_section,
+    setting => 'resource',
+    value   => "\"${auth_resource}\"",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} backend":
+    section => $auth_section,
+    setting => 'backend',
+    value   => "\"${backend}\"",
+  }
+
+}
+

--- a/manifests/config/authentication_msldap.pp
+++ b/manifests/config/authentication_msldap.pp
@@ -6,24 +6,35 @@ define icingaweb2::config::authentication_msldap (
   $auth_section = $title,
   $auth_resource = undef,
   $backend = 'msldap',
+  $filter = '!(objectComputer)',
+  $base_dn = undef,
 ){
 
   Ini_Setting {
     ensure  => present,
+    section => $auth_section,
     require => File["${::icingaweb2::config_dir}/authentication.ini"],
     path    => "${::icingaweb2::config_dir}/authentication.ini",
   }
 
   ini_setting { "icingaweb2 authentication ${title} resource":
-    section => $auth_section,
     setting => 'resource',
     value   => "\"${auth_resource}\"",
   }
 
   ini_setting { "icingaweb2 authentication ${title} backend":
-    section => $auth_section,
     setting => 'backend',
     value   => "\"${backend}\"",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} filter":
+    setting => 'filter',
+    value   => "\"${filter}\"",
+  }
+
+  ini_setting { "icingaweb2 authentication ${title} base_dn":
+    setting => 'base_dn',
+    value   => "\"${base_dn}\"",
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -296,6 +296,18 @@ class icingaweb2 (
     }
   }
 
+  if $::icingaweb2::auth_backend == 'msldap' {
+    validate_integer($ldap_port)
+    validate_string($auth_ldap_base_dn)
+    validate_string($auth_ldap_filter)
+    validate_string($auth_ldap_user_class)
+    validate_string($auth_ldap_user_name_attribute)
+    validate_string($ldap_host)
+    validate_string($ldap_bind_dn)
+    validate_string($ldap_bind_pw)
+    validate_string($ldap_root_dn)
+  }
+
   if $::icingaweb2::manage_apache_vhost {
     validate_string($template_apache)
   }


### PR DESCRIPTION
Hacky backport of the msldap user auth from the puppet 4.x module to work in puppet 3 required for connecting user auth to the AD servers

This is tested and currently deployed to the Sun np01 environment